### PR TITLE
Fixed typographical error, changed acomplish to accomplish in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -106,7 +106,7 @@ Next Goals
 ==========
 
 - Finish implementation of `connect()`
-- Modify `send()` to acomplish TCP client sockets
+- Modify `send()` to accomplish TCP client sockets
 - Implement `sendto()` and `recvfrom()` (UDP)
 - Support for multiple sockets
 - Put all the features of `ip_arp_udp_tcp.c` in `socket.c`


### PR DESCRIPTION
@turicas, I've corrected a typographical error in the documentation of the [Ethernet_ENC28J60](https://github.com/turicas/Ethernet_ENC28J60) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
